### PR TITLE
New RW analysis tab

### DIFF
--- a/client/FFRKInspector.csproj
+++ b/client/FFRKInspector.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -84,6 +85,7 @@
     <Compile Include="DataCache\Worlds.cs" />
     <Compile Include="EquipmentStatsDataSet.cs">
       <DependentUpon>EquipmentStatsDataSet.xsd</DependentUpon>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="EquipmentStatsDataSet.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -109,6 +111,9 @@
     <Compile Include="GameData\DataUserDungeon.cs" />
     <Compile Include="GameData\EquipmentUsage.cs" />
     <Compile Include="GameData\EquipStats.cs" />
+    <Compile Include="GameData\RWs\DataRelationPackage.cs" />
+    <Compile Include="GameData\RWs\DataDungeonFellowListing.cs" />
+    <Compile Include="GameData\RWs\DataTargetProfiles.cs" />
     <Compile Include="GameData\StatCalculator.cs" />
     <Compile Include="MissingItemsDataSet1.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -135,7 +140,10 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
+    <Compile Include="GameData\RWs\DataRelatedRW.cs" />
+    <Compile Include="GameData\RWs\DataAllRelations.cs" />
     <Compile Include="Proxy\HandleAppInitData.cs" />
+    <Compile Include="Proxy\HandleFollowersAndFollowees.cs" />
     <Compile Include="Proxy\HandleGachaSeriesDetails.cs" />
     <Compile Include="Proxy\HandleGachaSeriesList.cs" />
     <Compile Include="Proxy\HandleListBattles.cs" />
@@ -202,6 +210,12 @@
     </Compile>
     <Compile Include="UI\FFRKViewDebugging.Designer.cs">
       <DependentUpon>FFRKViewDebugging.cs</DependentUpon>
+    </Compile>
+    <Compile Include="UI\FFRKViewRWs.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UI\FFRKViewRWs.Designer.cs">
+      <DependentUpon>FFRKViewRWs.cs</DependentUpon>
     </Compile>
     <Compile Include="UI\FFRKViewGacha.cs">
       <SubType>UserControl</SubType>
@@ -301,6 +315,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UI\DatabaseUI\FFRKViewDatabase.resx">
       <DependentUpon>FFRKViewDatabase.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UI\FFRKViewRWs.resx">
+      <DependentUpon>FFRKViewRWs.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UI\FFRKViewGacha.resx">
       <DependentUpon>FFRKViewGacha.cs</DependentUpon>

--- a/client/GameData/GameState.cs
+++ b/client/GameData/GameState.cs
@@ -1,4 +1,5 @@
 ﻿using FFRKInspector.GameData.Party;
+using FFRKInspector.GameData.RWs;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,6 +15,7 @@ namespace FFRKInspector.GameData
         private DataGachaSeriesList mGachas;
         private DataPartyDetails mParty;
         private AppInit.AppInitData mAppInitData;
+        private List<DataRelatedRW> mRelatedRWs;
 
         public GameState()
         {
@@ -21,6 +23,7 @@ namespace FFRKInspector.GameData
             mActiveDungeon = null;
             mGachas = null;
             mAppInitData = null;
+            mRelatedRWs = null;
         }
 
         public EventBattleInitiated ActiveBattle
@@ -51,6 +54,12 @@ namespace FFRKInspector.GameData
         {
             get { return mAppInitData; }
             set { mAppInitData = value; }
+        }
+
+        public List<DataRelatedRW> RelatedRWs
+        {
+            get { return mRelatedRWs; }
+            set { mRelatedRWs = value; }
         }
     }
 }

--- a/client/GameData/RWs/DataAllRelations.cs
+++ b/client/GameData/RWs/DataAllRelations.cs
@@ -1,0 +1,19 @@
+﻿using FFRKInspector.GameData.Converters;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFRKInspector.GameData.RWs
+{
+    class DataAllRelations
+    {
+        [JsonProperty("followers")]
+        public DataRelationPackage Followers;
+
+        [JsonProperty("followees")]
+        public DataRelationPackage Followees;
+    }
+}

--- a/client/GameData/RWs/DataDungeonFellowListing.cs
+++ b/client/GameData/RWs/DataDungeonFellowListing.cs
@@ -1,0 +1,19 @@
+﻿using FFRKInspector.GameData.Converters;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFRKInspector.GameData.RWs
+{
+    class DataDungeonFellowListing
+    {
+        [JsonProperty("detailed_fellows")]
+        public List<DataTargetProfile> Profiles;
+
+        [JsonProperty("fellow_listing_user_ids")]
+        public List<Object> ObjectUserID;
+    }
+}

--- a/client/GameData/RWs/DataRelatedRW.cs
+++ b/client/GameData/RWs/DataRelatedRW.cs
@@ -1,0 +1,113 @@
+﻿using FFRKInspector.GameData.Converters;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+
+namespace FFRKInspector.GameData.RWs
+{
+    class DataRelatedRW
+    {
+        public enum Relationship
+        {
+            Random,
+            Follower,
+            Followee,
+            Mutual
+        };
+
+        //user relation and target profile data combined here.
+        //  An array of this is stored in GameState with all followers AND followees, UI to differentiate by relation_status value (1 is follower, 2 is followee, 3 is mutual)
+
+        ///relation_status = 0 is no relation (random options from battle selection), 1 is follower, 2 is followee, 3 is mutual
+        [JsonProperty("relation_status")]
+        public byte RelationStatus;
+
+        [JsonProperty("target_user_id")]
+        public ulong UserID;
+
+        //Fields below this point come from the 'profile' data structures
+
+        ///nickname = player name (for identification in app list)
+        [JsonProperty(PropertyName = "nickname", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue("")]
+        public string NickName;
+
+        ///profile_message = slogan (for identification in app list)
+        [JsonProperty(PropertyName = "profile_message", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue("")]
+        public string Slogan;
+
+        ///supporter_buddy_soul_strike_name = name of the SB
+        [JsonProperty(PropertyName = "supporter_buddy_soul_strike_name", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue("")]
+        public string SBName;
+
+        ///supporter_buddy_soul_strike_type = Uncertain, but may be useful for auto-selecting the primary stat for the SB
+        [JsonProperty(PropertyName = "supporter_buddy_soul_strike_type", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 SBType;
+
+        ///supporter_buddy_acc = accuracy
+        [JsonProperty(PropertyName = "supporter_buddy_acc", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 Accuracy;
+
+        ///supporter_buddy_atk = attack
+        [JsonProperty(PropertyName = "supporter_buddy_atk", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 Attack;
+
+        ///supporter_buddy_matk = magic
+        [JsonProperty(PropertyName = "supporter_buddy_matk", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 Magic;
+
+        ///supporter_buddy_mnd = mind
+        [JsonProperty(PropertyName = "supporter_buddy_mnd", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 Mind;
+
+        ///supporter_buddy_spd = speed
+        [JsonProperty(PropertyName = "supporter_buddy_spd", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 Speed;
+
+        public DataRelatedRW(ulong User, byte Relation)
+        {
+            this.UserID = User;
+            this.RelationStatus = Relation;
+        }
+
+        public DataRelatedRW UpdateRWData(DataRelatedRW NewRW)
+        {   
+            this.Accuracy = NewRW.Accuracy;
+            this.Attack = NewRW.Attack;
+            this.Magic = NewRW.Magic;
+            this.Mind = NewRW.Mind;
+            this.NickName = NewRW.NickName;
+            this.SBName = NewRW.SBName;
+            this.SBType = NewRW.SBType;
+            this.Slogan = NewRW.Slogan;
+            this.Speed = NewRW.Speed;
+            return this;
+        }
+
+        public DataRelatedRW UpdateRWData(DataTargetProfile NewRW)
+        {   
+            this.Accuracy = NewRW.Accuracy;
+            this.Attack = NewRW.Attack;
+            this.Magic = NewRW.Magic;
+            this.Mind = NewRW.Mind;
+            this.NickName = NewRW.NickName;
+            this.SBName = NewRW.SBName;
+            this.SBType = NewRW.SBType;
+            this.Slogan = NewRW.Slogan;
+            this.Speed = NewRW.Speed;
+            return this;
+        }
+    }
+}

--- a/client/GameData/RWs/DataRelationPackage.cs
+++ b/client/GameData/RWs/DataRelationPackage.cs
@@ -1,0 +1,19 @@
+﻿using FFRKInspector.GameData.Converters;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFRKInspector.GameData.RWs
+{
+    class DataRelationPackage
+    {
+        [JsonProperty("target_profiles")]
+        public List<DataTargetProfile> Profiles;
+
+        [JsonProperty("user_relations")]
+        public List<DataRelatedRW> Users;
+    }
+}

--- a/client/GameData/RWs/DataTargetProfiles.cs
+++ b/client/GameData/RWs/DataTargetProfiles.cs
@@ -1,0 +1,67 @@
+﻿using FFRKInspector.GameData.Converters;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+
+namespace FFRKInspector.GameData.RWs
+{
+    class DataTargetProfile
+    {
+        //relation_status = 0 is no relation (from battle selection), 1 is follower, 2 is followee, 3 is mutual
+        [JsonProperty("relation_status", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public byte RelationStatus;
+
+        [JsonProperty("user_id")]
+        public ulong UserID;
+
+        ///nickname = player name (for identification in app list)
+        [JsonProperty(PropertyName = "nickname", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue("")]
+        public string NickName;
+
+        ///profile_message = slogan (for identification in app list)
+        [JsonProperty(PropertyName = "profile_message", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue("")]
+        public string Slogan;
+
+        ///supporter_buddy_soul_strike_name = name of the SB
+        [JsonProperty(PropertyName = "supporter_buddy_soul_strike_name", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue("")]
+        public string SBName;
+
+        ///supporter_buddy_soul_strike_type = Uncertain, but may be useful for auto-selecting the primary stat for the SB
+        [JsonProperty(PropertyName = "supporter_buddy_soul_strike_type", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 SBType;
+
+        ///supporter_buddy_acc = accuracy
+        [JsonProperty(PropertyName = "supporter_buddy_acc", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 Accuracy;
+
+        ///supporter_buddy_atk = attack
+        [JsonProperty(PropertyName = "supporter_buddy_atk", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 Attack;
+
+        ///supporter_buddy_matk = magic
+        [JsonProperty(PropertyName = "supporter_buddy_matk", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 Magic;
+
+        ///supporter_buddy_mnd = mind
+        [JsonProperty(PropertyName = "supporter_buddy_mnd", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 Mind;
+
+        ///supporter_buddy_spd = speed
+        [JsonProperty(PropertyName = "supporter_buddy_spd", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(0)]
+        public UInt16 Speed;
+    }
+}

--- a/client/Proxy/FFRKProxy.cs
+++ b/client/Proxy/FFRKProxy.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 using Fiddler;
 using FFRKInspector.Database;
 using FFRKInspector.GameData;
+using FFRKInspector.GameData.RWs;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using FFRKInspector.UI;
@@ -73,6 +74,7 @@ namespace FFRKInspector.Proxy
             mResponseHandlers.Add(new HandleGachaSeriesList());
             mResponseHandlers.Add(new HandleGachaSeriesDetails());
             mResponseHandlers.Add(new HandleCompleteBattle());
+            mResponseHandlers.Add(new HandleFollowersAndFollowees());
 
             mHistory = new ResponseHistory();
             mGameState = new GameState();
@@ -266,6 +268,7 @@ namespace FFRKInspector.Proxy
         internal void RaiseLeaveDungeon() { if (OnLeaveDungeon != null) OnLeaveDungeon(); }
         internal void RaiseBattleComplete(EventBattleInitiated original_battle) { if (OnCompleteBattle != null) OnCompleteBattle(original_battle); }
         internal void RaisePartyList(DataPartyDetails party) { if (OnPartyList != null) OnPartyList(party); }
+        internal void RaiseRWList(List<DataRelatedRW> RWs) { if (OnRWList != null) OnRWList(RWs); }
 
         internal delegate void BattleInitiatedDelegate(EventBattleInitiated battle);
         internal delegate void BattleResultDelegate(EventBattleInitiated battle);
@@ -275,6 +278,7 @@ namespace FFRKInspector.Proxy
         internal delegate void FFRKDefaultDelegate();
         internal delegate void FFRKResponseDelegate(string Path);
         internal delegate void FFRKPartyListDelegate(DataPartyDetails party);
+        internal delegate void FFRKRWListDelegate(List<DataRelatedRW> RWs);
 
         internal event BattleInitiatedDelegate OnBattleEngaged;
         internal event ListBattlesDelegate OnListBattles;
@@ -285,5 +289,6 @@ namespace FFRKInspector.Proxy
         internal event FFRKResponseDelegate OnFFRKResponse;
         internal event FFRKDefaultDelegate OnItemCacheRefreshed;
         internal event FFRKPartyListDelegate OnPartyList;
+        internal event FFRKRWListDelegate OnRWList;
     }
 }

--- a/client/Proxy/HandleFollowersAndFollowees.cs
+++ b/client/Proxy/HandleFollowersAndFollowees.cs
@@ -1,0 +1,108 @@
+﻿using FFRKInspector.Database;
+using FFRKInspector.GameData;
+using FFRKInspector.GameData.RWs;
+using Fiddler;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFRKInspector.Proxy
+{
+    /// <summary>
+    /// When first opened the Friends list gets a /dff/relation/followee_and_follower_list response containing for 
+    ///     followers and followees both:
+    ///         the first 5 'target_profiles' (all the RW stats, gear, etc, & the player name, id, slogan, etc)
+    ///         a list of all 'user_relations' (user_id mappings)
+    /// As you scroll you get one response of /dff/relation/find_by_user_ids per page with 5 target_profiles and thier related user_relations records
+    /// The find_by_user_ids responses do not indicate whether they correspond with followers or followees. That is apparently left up to the app
+    /// 
+    /// parsing:
+    ///     build a DB of followees by userid, leave most of data blank until the user id comes up in a target_profile.
+    ///     keep these data points from target_profile
+    /// </summary>
+    class HandleFollowersAndFollowees : SimpleResponseHandler
+    {
+        public override bool CanHandle(Session Session)
+        {
+            string RequestPath = Session.oRequest.headers.RequestPath;
+            return RequestPath.Equals("/dff/relation/followee_and_follower_list", StringComparison.CurrentCultureIgnoreCase) //initial response from friends list from Menu
+                || RequestPath.Equals("/dff/relation/find_by_user_ids", StringComparison.CurrentCultureIgnoreCase)           //loading next page from friends list OR battle select screen
+                || RequestPath.Equals("/dff/relation/detailed_fellow_listing", StringComparison.CurrentCultureIgnoreCase);   //initial response from battle select screen
+        }
+
+        public override void Handle(Session Session)
+        {
+            List<DataRelatedRW> RWs = new List<DataRelatedRW>();
+            List<DataRelatedRW> Users = new List<DataRelatedRW>();
+            List<DataTargetProfile> Profiles = new List<DataTargetProfile>();
+
+            if (Session.oRequest.headers.RequestPath.Equals("/dff/relation/followee_and_follower_list", StringComparison.CurrentCultureIgnoreCase))
+            {   
+                //We just opened the friends list. get all the user_relations and the target_profiles rcvd
+                DataAllRelations FolloweesFollowers = JsonConvert.DeserializeObject<DataAllRelations>(GetResponseBody(Session));
+                
+                //List of all user IDs, taking only follower records (status 1) from the followers list (no mutual duplication)
+                Users.AddRange(FolloweesFollowers.Followees.Users);
+                Users.AddRange(FolloweesFollowers.Followers.Users.Where((rw) => rw.RelationStatus == (byte)DataRelatedRW.Relationship.Follower));
+
+                Profiles.AddRange(FolloweesFollowers.Followees.Profiles);
+                Profiles.AddRange(FolloweesFollowers.Followers.Profiles);
+            }
+
+            if (Session.oRequest.headers.RequestPath.Equals("/dff/relation/find_by_user_ids", StringComparison.CurrentCultureIgnoreCase))
+            {
+                //extract the DataRelatedRW records and the target_profiles
+                DataRelationPackage RelationsPackage = JsonConvert.DeserializeObject<DataRelationPackage>(GetResponseBody(Session));
+                Users.AddRange(RelationsPackage.Users);
+                Profiles.AddRange(RelationsPackage.Profiles);
+            }
+
+            if (Session.oRequest.headers.RequestPath.Equals("/dff/relation/detailed_fellow_listing", StringComparison.CurrentCultureIgnoreCase))
+            {
+                //got a fellow listing at the dungeon entrance screen
+                DataDungeonFellowListing RelationsPackage = JsonConvert.DeserializeObject<DataDungeonFellowListing>(GetResponseBody(Session));
+                foreach (DataTargetProfile DetailedProfile in RelationsPackage.Profiles)
+                    Users.Add(new DataRelatedRW(DetailedProfile.UserID, DetailedProfile.RelationStatus).UpdateRWData(DetailedProfile));
+            }
+
+            //Merge profile data into user list 
+            foreach (DataTargetProfile ProfileData in Profiles)
+            {
+                DataRelatedRW RW = Users.FirstOrDefault(a => a.UserID == ProfileData.UserID);
+                if (RW != null)
+                {
+                    RW.UpdateRWData(ProfileData);
+                }
+            }
+
+            //Update existing list of RWs and add new RWs
+            List<DataRelatedRW> AllRWs = FFRKProxy.Instance.GameState.RelatedRWs;
+            if (AllRWs == null)
+            {
+                AllRWs = new List<DataRelatedRW>();
+            }
+
+            foreach (DataRelatedRW NewRW in Users)
+            {
+                DataRelatedRW ExistingRW = AllRWs.FirstOrDefault(a => a.UserID == NewRW.UserID);
+                if (ExistingRW != null)
+                {
+                    //Update if we have existing data
+                    if (NewRW.SBName != "")
+                        ExistingRW.UpdateRWData(NewRW);
+                }
+                else
+                {
+                    //Otherwise it's added completely new
+                    AllRWs.Add(NewRW);
+                }
+            }
+                
+            FFRKProxy.Instance.GameState.RelatedRWs = AllRWs;
+            FFRKProxy.Instance.RaiseRWList(AllRWs);
+        }
+    }
+}

--- a/client/UI/FFRKTabInspector.Designer.cs
+++ b/client/UI/FFRKTabInspector.Designer.cs
@@ -45,6 +45,8 @@
             this.ffrkViewAbout1 = new FFRKInspector.UI.FFRKViewAbout();
             this.tabPageDebug = new System.Windows.Forms.TabPage();
             this.ffrkViewDebugging1 = new FFRKInspector.UI.FFRKViewDebugging();
+            this.tabPageRWs = new System.Windows.Forms.TabPage();
+            this.ffrkViewRWs1 = new FFRKInspector.UI.FFRKViewRWs();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripStatusLabelConnection = new System.Windows.Forms.ToolStripStatusLabel();
@@ -57,6 +59,7 @@
             this.tabPageGacha.SuspendLayout();
             this.tabPageAbout.SuspendLayout();
             this.tabPageDebug.SuspendLayout();
+            this.tabPageRWs.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -70,6 +73,7 @@
             this.tabControlFFRKInspector.Controls.Add(this.tabPageGacha);
             this.tabControlFFRKInspector.Controls.Add(this.tabPageAbout);
             this.tabControlFFRKInspector.Controls.Add(this.tabPageDebug);
+            this.tabControlFFRKInspector.Controls.Add(this.tabPageRWs);
             this.tabControlFFRKInspector.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControlFFRKInspector.Location = new System.Drawing.Point(0, 0);
             this.tabControlFFRKInspector.Name = "tabControlFFRKInspector";
@@ -226,6 +230,24 @@
             this.ffrkViewDebugging1.Size = new System.Drawing.Size(983, 590);
             this.ffrkViewDebugging1.TabIndex = 0;
             // 
+            // tabPageRWs
+            // 
+            this.tabPageRWs.Controls.Add(this.ffrkViewRWs1);
+            this.tabPageRWs.Location = new System.Drawing.Point(4, 22);
+            this.tabPageRWs.Name = "tabPageRWs";
+            this.tabPageRWs.Size = new System.Drawing.Size(983, 590);
+            this.tabPageRWs.TabIndex = 11;
+            this.tabPageRWs.Text = "Roaming Warriors";
+            this.tabPageRWs.UseVisualStyleBackColor = true;
+            // 
+            // ffrkViewRWs1
+            // 
+            this.ffrkViewRWs1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ffrkViewRWs1.Location = new System.Drawing.Point(0, 0);
+            this.ffrkViewRWs1.Name = "ffrkViewRWs1";
+            this.ffrkViewRWs1.Size = new System.Drawing.Size(983, 590);
+            this.ffrkViewRWs1.TabIndex = 0;
+            // 
             // statusStrip1
             // 
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -267,6 +289,7 @@
             this.tabPageGacha.ResumeLayout(false);
             this.tabPageAbout.ResumeLayout(false);
             this.tabPageDebug.ResumeLayout(false);
+            this.tabPageRWs.ResumeLayout(false);
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
             this.ResumeLayout(false);
@@ -296,5 +319,7 @@
         private System.Windows.Forms.TabPage tabPageBattle;
         private FFRKViewActiveBattle ffrkViewActiveBattle;
         private FFRKViewInventory ffrkViewInventory1;
+        private System.Windows.Forms.TabPage tabPageRWs;
+        private FFRKViewRWs ffrkViewRWs1;
     }
 }

--- a/client/UI/FFRKTabInspector.cs
+++ b/client/UI/FFRKTabInspector.cs
@@ -26,7 +26,8 @@ namespace FFRKInspector.UI
             Database,
             Gacha,
             About,
-            Debugging
+            Debugging,
+            RWs
         }
 
         public FFRKTabInspector()
@@ -39,6 +40,7 @@ namespace FFRKInspector.UI
             tabPageGacha.Tag = InspectorPage.Gacha;
             tabPageInventory.Tag = InspectorPage.Inventory;
             tabPageSearch.Tag = InspectorPage.ItemSearch;
+            tabPageRWs.Tag = InspectorPage.RWs;
         }
 
         private void FFRKTabInspectorView_Load(object sender, EventArgs e)

--- a/client/UI/FFRKViewRWs.Designer.cs
+++ b/client/UI/FFRKViewRWs.Designer.cs
@@ -1,0 +1,223 @@
+﻿namespace FFRKInspector.UI
+{
+    partial class FFRKViewRWs
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.Windows.Forms.DataVisualization.Charting.ChartArea chartArea1 = new System.Windows.Forms.DataVisualization.Charting.ChartArea();
+            System.Windows.Forms.DataVisualization.Charting.Legend legend1 = new System.Windows.Forms.DataVisualization.Charting.Legend();
+            System.Windows.Forms.DataVisualization.Charting.Series series1 = new System.Windows.Forms.DataVisualization.Charting.Series();
+            System.Windows.Forms.DataVisualization.Charting.Title title1 = new System.Windows.Forms.DataVisualization.Charting.Title();
+            System.Windows.Forms.DataVisualization.Charting.ChartArea chartArea2 = new System.Windows.Forms.DataVisualization.Charting.ChartArea();
+            System.Windows.Forms.DataVisualization.Charting.Legend legend2 = new System.Windows.Forms.DataVisualization.Charting.Legend();
+            System.Windows.Forms.DataVisualization.Charting.Series series2 = new System.Windows.Forms.DataVisualization.Charting.Series();
+            System.Windows.Forms.DataVisualization.Charting.Title title2 = new System.Windows.Forms.DataVisualization.Charting.Title();
+            System.Windows.Forms.DataVisualization.Charting.ChartArea chartArea3 = new System.Windows.Forms.DataVisualization.Charting.ChartArea();
+            System.Windows.Forms.DataVisualization.Charting.Legend legend3 = new System.Windows.Forms.DataVisualization.Charting.Legend();
+            System.Windows.Forms.DataVisualization.Charting.Series series3 = new System.Windows.Forms.DataVisualization.Charting.Series();
+            System.Windows.Forms.DataVisualization.Charting.Title title3 = new System.Windows.Forms.DataVisualization.Charting.Title();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            this.pchtFriendSB = new System.Windows.Forms.DataVisualization.Charting.Chart();
+            this.pchtMutualSB = new System.Windows.Forms.DataVisualization.Charting.Chart();
+            this.pchtFollowerSB = new System.Windows.Forms.DataVisualization.Charting.Chart();
+            this.dataGridViewRWs = new FFRKInspector.UI.DataGridViewEx();
+            this.dgcNickname = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dgcRelation = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dgcSBName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dgcFriendCode = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ((System.ComponentModel.ISupportInitialize)(this.pchtFriendSB)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pchtMutualSB)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pchtFollowerSB)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewRWs)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // pchtFriendSB
+            // 
+            chartArea1.Name = "ChartArea1";
+            this.pchtFriendSB.ChartAreas.Add(chartArea1);
+            legend1.Name = "Friends SBs";
+            this.pchtFriendSB.Legends.Add(legend1);
+            this.pchtFriendSB.Location = new System.Drawing.Point(473, 4);
+            this.pchtFriendSB.Name = "pchtFriendSB";
+            series1.ChartArea = "ChartArea1";
+            series1.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Pie;
+            series1.Legend = "Friends SBs";
+            series1.Name = "Series1";
+            series1.XValueMember = "FriendSeries.SBName";
+            series1.YValueMembers = "FriendSeries.Count";
+            this.pchtFriendSB.Series.Add(series1);
+            this.pchtFriendSB.Size = new System.Drawing.Size(415, 285);
+            this.pchtFriendSB.TabIndex = 1;
+            this.pchtFriendSB.Text = "Friends";
+            title1.Docking = System.Windows.Forms.DataVisualization.Charting.Docking.Left;
+            title1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            title1.Name = "Title1";
+            title1.Text = "Friends";
+            title1.TextOrientation = System.Windows.Forms.DataVisualization.Charting.TextOrientation.Rotated270;
+            this.pchtFriendSB.Titles.Add(title1);
+            // 
+            // pchtMutualSB
+            // 
+            chartArea2.Name = "ChartArea1";
+            this.pchtMutualSB.ChartAreas.Add(chartArea2);
+            legend2.Name = "Friends SBs";
+            this.pchtMutualSB.Legends.Add(legend2);
+            this.pchtMutualSB.Location = new System.Drawing.Point(472, 295);
+            this.pchtMutualSB.Name = "pchtMutualSB";
+            series2.ChartArea = "ChartArea1";
+            series2.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Pie;
+            series2.Legend = "Friends SBs";
+            series2.Name = "Series1";
+            series2.XValueMember = "FriendSeries.SBName";
+            series2.YValueMembers = "FriendSeries.Count";
+            this.pchtMutualSB.Series.Add(series2);
+            this.pchtMutualSB.Size = new System.Drawing.Size(415, 285);
+            this.pchtMutualSB.TabIndex = 2;
+            this.pchtMutualSB.Text = "chart1";
+            title2.Docking = System.Windows.Forms.DataVisualization.Charting.Docking.Left;
+            title2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            title2.Name = "Title1";
+            title2.Text = "Mutuals";
+            title2.TextOrientation = System.Windows.Forms.DataVisualization.Charting.TextOrientation.Rotated270;
+            this.pchtMutualSB.Titles.Add(title2);
+            // 
+            // pchtFollowerSB
+            // 
+            chartArea3.Name = "ChartArea1";
+            this.pchtFollowerSB.ChartAreas.Add(chartArea3);
+            legend3.Name = "Friends SBs";
+            this.pchtFollowerSB.Legends.Add(legend3);
+            this.pchtFollowerSB.Location = new System.Drawing.Point(472, 586);
+            this.pchtFollowerSB.Name = "pchtFollowerSB";
+            series3.ChartArea = "ChartArea1";
+            series3.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Pie;
+            series3.Legend = "Friends SBs";
+            series3.Name = "Series1";
+            series3.XValueMember = "FriendSeries.SBName";
+            series3.YValueMembers = "FriendSeries.Count";
+            this.pchtFollowerSB.Series.Add(series3);
+            this.pchtFollowerSB.Size = new System.Drawing.Size(415, 285);
+            this.pchtFollowerSB.TabIndex = 3;
+            this.pchtFollowerSB.Text = "chart1";
+            title3.Docking = System.Windows.Forms.DataVisualization.Charting.Docking.Left;
+            title3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            title3.Name = "Title1";
+            title3.Text = "Followers";
+            title3.TextOrientation = System.Windows.Forms.DataVisualization.Charting.TextOrientation.Rotated270;
+            this.pchtFollowerSB.Titles.Add(title3);
+            // 
+            // dataGridViewRWs
+            // 
+            this.dataGridViewRWs.AllowUserToAddRows = false;
+            this.dataGridViewRWs.AllowUserToDeleteRows = false;
+            this.dataGridViewRWs.AllowUserToOrderColumns = true;
+            this.dataGridViewRWs.AllowUserToResizeRows = false;
+            dataGridViewCellStyle1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(252)))), ((int)(((byte)(213)))), ((int)(((byte)(180)))));
+            this.dataGridViewRWs.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle1;
+            this.dataGridViewRWs.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewRWs.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.dgcNickname,
+            this.dgcRelation,
+            this.dgcSBName,
+            this.dgcFriendCode});
+            this.dataGridViewRWs.Location = new System.Drawing.Point(19, 3);
+            this.dataGridViewRWs.Name = "dataGridViewRWs";
+            this.dataGridViewRWs.ReadOnly = true;
+            this.dataGridViewRWs.RowHeadersVisible = false;
+            dataGridViewCellStyle2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(210)))), ((int)(((byte)(228)))));
+            this.dataGridViewRWs.RowsDefaultCellStyle = dataGridViewCellStyle2;
+            this.dataGridViewRWs.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.dataGridViewRWs.ShowEditingIcon = false;
+            this.dataGridViewRWs.Size = new System.Drawing.Size(447, 868);
+            this.dataGridViewRWs.TabIndex = 0;
+            // 
+            // dgcNickname
+            // 
+            this.dgcNickname.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.dgcNickname.HeaderText = "Name";
+            this.dgcNickname.MinimumWidth = 50;
+            this.dgcNickname.Name = "dgcNickname";
+            this.dgcNickname.ReadOnly = true;
+            this.dgcNickname.Width = 60;
+            // 
+            // dgcRelation
+            // 
+            this.dgcRelation.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.dgcRelation.HeaderText = "Relation";
+            this.dgcRelation.Name = "dgcRelation";
+            this.dgcRelation.ReadOnly = true;
+            this.dgcRelation.Width = 71;
+            // 
+            // dgcSBName
+            // 
+            this.dgcSBName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.dgcSBName.HeaderText = "SB Name";
+            this.dgcSBName.MinimumWidth = 60;
+            this.dgcSBName.Name = "dgcSBName";
+            this.dgcSBName.ReadOnly = true;
+            this.dgcSBName.Width = 77;
+            // 
+            // dgcFriendCode
+            // 
+            this.dgcFriendCode.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.dgcFriendCode.HeaderText = "Friend Code";
+            this.dgcFriendCode.Name = "dgcFriendCode";
+            this.dgcFriendCode.ReadOnly = true;
+            this.dgcFriendCode.Width = 89;
+            // 
+            // FFRKViewRWs
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.pchtFollowerSB);
+            this.Controls.Add(this.pchtMutualSB);
+            this.Controls.Add(this.pchtFriendSB);
+            this.Controls.Add(this.dataGridViewRWs);
+            this.Name = "FFRKViewRWs";
+            this.Size = new System.Drawing.Size(891, 878);
+            this.Load += new System.EventHandler(this.FFRKViewInventory_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.pchtFriendSB)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pchtMutualSB)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pchtFollowerSB)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewRWs)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private DataGridViewEx dataGridViewRWs;
+        private System.Windows.Forms.DataVisualization.Charting.Chart pchtFriendSB;
+        private System.Windows.Forms.DataVisualization.Charting.Chart pchtMutualSB;
+        private System.Windows.Forms.DataVisualization.Charting.Chart pchtFollowerSB;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dgcNickname;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dgcRelation;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dgcSBName;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dgcFriendCode;
+    }
+}

--- a/client/UI/FFRKViewRWs.cs
+++ b/client/UI/FFRKViewRWs.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Windows.Forms.DataVisualization.Charting;
+using FFRKInspector.Proxy;
+using FFRKInspector.GameData.RWs;
+using FFRKInspector.UI.ListViewFields;
+using FFRKInspector.GameData;
+using FFRKInspector.DataCache;
+using FFRKInspector.Analyzer;
+using System.Diagnostics;
+using System.IO;
+
+namespace FFRKInspector.UI
+{
+    public partial class FFRKViewRWs : UserControl
+    {
+        class ChartSeriesItem
+        {
+            public string SBName;
+            public int Count;
+        }
+
+        public FFRKViewRWs()
+        {
+            InitializeComponent();
+        }
+
+        private void FFRKViewInventory_Load(object sender, EventArgs e)
+        {
+            if (DesignMode)
+                return;
+
+            if (FFRKProxy.Instance != null)
+            {
+                FFRKProxy.Instance.OnRWList += FFRKProxy_OnRWList;
+
+                List<DataRelatedRW> RWs = FFRKProxy.Instance.GameState.RelatedRWs;
+                if (RWs != null)
+                {
+                    UpdateRWGrid(RWs);
+                    UpdatePieCharts(RWs);
+                }
+            }
+        }
+
+        void FFRKProxy_OnRWList(List<DataRelatedRW> RWs)
+        {
+            BeginInvoke((Action)(() =>
+            {
+                UpdateRWGrid(RWs);
+                UpdatePieCharts(RWs);
+            }));
+        }
+
+        private void UpdatePieCharts(List<DataRelatedRW> RWs)
+        {
+            Dictionary<string, int> FriendSeries = GetSeriesDict(RWs, DataRelatedRW.Relationship.Followee);
+            if (FriendSeries.Count > 0)
+            {
+                pchtFriendSB.Series[0].Points.DataBindXY(FriendSeries.Keys, FriendSeries.Values);
+                pchtFriendSB.Series[0].Label = "#AXISLABEL - #PERCENT{P0}";
+                pchtFriendSB.Series[0]["PieLabelStyle"] = "Disabled";
+                pchtFriendSB.Invalidate();
+            }
+
+            Dictionary<string, int> MutualSeries = GetSeriesDict(RWs, DataRelatedRW.Relationship.Mutual);
+            if (MutualSeries.Count > 0)
+            {
+                pchtMutualSB.Series[0].Points.DataBindXY(MutualSeries.Keys, MutualSeries.Values);
+                pchtMutualSB.Series[0].Label = "#AXISLABEL - #PERCENT{P0}";
+                pchtMutualSB.Series[0]["PieLabelStyle"] = "Disabled";
+                pchtMutualSB.Invalidate();
+            }
+            
+            Dictionary<string, int> FollowerSeries = GetSeriesDict(RWs, DataRelatedRW.Relationship.Follower);
+            if (FollowerSeries.Count > 0)
+            {
+                pchtFollowerSB.Series[0].Points.DataBindXY(FollowerSeries.Keys, FollowerSeries.Values);
+                pchtFollowerSB.Series[0].Label = "#AXISLABEL - #PERCENT{P0}";
+                pchtFollowerSB.Series[0]["PieLabelStyle"] = "Disabled";
+                pchtFollowerSB.Invalidate();        
+            }
+        }
+
+        private static Dictionary<string, int> GetSeriesDict(List<DataRelatedRW> RWs, DataRelatedRW.Relationship Relationship)
+        {
+            Dictionary<string, int> SeriesDict;
+            List<ChartSeriesItem> SeriesList = RWs.Where(rw => rw.RelationStatus == (int)Relationship)
+                             .GroupBy(rw => rw.SBName)
+                             .Select(sb => new ChartSeriesItem { SBName = sb.Key, Count = sb.Distinct().Count() }).ToList<ChartSeriesItem>();
+            //Change blank row SB names to 'Unknown'
+            foreach (var fr in SeriesList.Where(x => x.SBName == ""))
+            {
+                fr.SBName = "Unknown";
+            }
+            SeriesDict = new Dictionary<string, int>(SeriesList.OrderByDescending(x => x.Count).ToDictionary(k => k.SBName, v => v.Count));
+            return SeriesDict;
+        }
+
+        private void UpdateRWGrid(List<DataRelatedRW> RWs)
+        {
+            dataGridViewRWs.Rows.Clear();
+            dataGridViewRWs.Rows.Add(RWs.Count);
+            int cur_row = 0;
+            foreach (DataRelatedRW RWData in RWs)
+            {
+                DataGridViewRow row = dataGridViewRWs.Rows[cur_row];
+                row.Tag = RWData;
+                row.Cells[dgcNickname.Name].Value = RWData.NickName;
+                row.Cells[dgcRelation.Name].Value = Enum.GetName(typeof(DataRelatedRW.Relationship), RWData.RelationStatus);
+                row.Cells[dgcSBName.Name].Value = RWData.SBName;
+                //TODO: Figure out how the hell to derive this from the UserID data
+                row.Cells[dgcFriendCode.Name].Value = "";
+
+                ++cur_row;
+            }
+        }
+    }
+}

--- a/client/UI/FFRKViewRWs.resx
+++ b/client/UI/FFRKViewRWs.resx
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="dgcNickname.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dgcRelation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dgcSBName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dgcFriendCode.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>


### PR DESCRIPTION
Updated submission of #3 with pie charts and sensitive user data removed from the UI. All the extra commits were squashed into a single clean commit of new functionality.

Creates an internal list of all RW data received including player nickname, slogan, soul break, and RW vital stats. Populates 'profile' information as it's received while viewing your Followers and Followees lists in the menu. Also captures data from the dungeon entrance RW selection screen including the randoms. A new UI tab displays basic data on all RWs received in a datagrid and a pie chart of SB % distribution for each relation type.

At this point nothing is saved to any external data storage. It's reasonable believe that the data collection might be useful to build a more automatic, detailed, and accurate 'Friend Code Spreadsheet' app by updating a RW profile database regularly. I haven't hacked how to derive friend codes from the available data but I suspect it's possible.
